### PR TITLE
fix: update hash for firmware v7.5.0

### DIFF
--- a/firmware/releases.json
+++ b/firmware/releases.json
@@ -3,7 +3,7 @@
     "firmware": {
       "version": "v7.5.0",
       "url": "v7.5.0/firmware.keepkey.bin",
-      "hash": "b1083a159b6ef4a576574d09c86255d02d634a41f0380ac71ecd1275bf297c09"
+      "hash": "08b1153a6e9ba5f45776094d62c8d055632d414a38f0c70acd1e751229bf097c"
     },
     "bootloader": {
       "version": "v2.1.4",
@@ -39,7 +39,7 @@
       "fe98454e7ebd4aef4a6db5bd4c60f52cf3f58b974283a7c1e1fcc5fea02cf3eb": "v2.1.4"
     },
     "firmware": {
-      "b1083a159b6ef4a576574d09c86255d02d634a41f0380ac71ecd1275bf297c09": "v7.5.0",
+      "08b1153a6e9ba5f45776094d62c8d055632d414a38f0c70acd1e751229bf097c": "v7.5.0",
       "43472b6fc1a3c9a2546ba771af830005f5758acbd9ea0679d4f20d480f63a040": "v7.4.0",
       "efcdcb32f199110e9a38010bc48d2acc66da89d41fb30c7d0b64c1ef74c90359": "v7.3.2",
       "47f3ead32f7be5926018163a2324f7dd1c47ef0b4cebec9bd8ae380d0a803314": "v7.3.1",


### PR DESCRIPTION
* replaces incorrect hash for firmware v7.5.0 binary